### PR TITLE
Fix version usage in ModelLookup

### DIFF
--- a/src/ModelLookup/ModelDiagram.tsx
+++ b/src/ModelLookup/ModelDiagram.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
+import { IModelVersion } from "./types"
 
-
-const ModelDiagram = (props:{selectedVersion: string}) => {
-    const {selectedVersion} = props;
+const ModelDiagram = (props: { selectedVersion: IModelVersion }) => {
+    const { selectedVersion } = props;
     const editorUrl = "https://kiegroup.github.io/kogito-online/?file=https://raw.githubusercontent.com/kiegroup/kogito-tooling/master/packages/online-editor/static/samples/sample.dmn#/editor/dmn";
     const kogitoIframe = () => {
-        return {__html: `<iframe src=${editorUrl} data-key="${selectedVersion}"></iframe>`};
+        return { __html: `<iframe src=${editorUrl} data-key="${selectedVersion.version}"></iframe>` };
     };
 
     return (

--- a/src/ModelLookup/ModelLookup.tsx
+++ b/src/ModelLookup/ModelLookup.tsx
@@ -1,5 +1,5 @@
-import React, {useState} from 'react';
-import {Divider, PageSection, PageSectionVariants} from "@patternfly/react-core";
+import React, { useState, } from 'react';
+import { Divider, PageSection, PageSectionVariants } from "@patternfly/react-core";
 import "./ModelLookup.scss";
 import ModelDiagram from "./ModelDiagram";
 import ModelVersionsBrowser from "./ModelVersionsBrowser";
@@ -39,12 +39,12 @@ const modelInfo = {
     ]
 };
 const ModelLookup = () => {
-    const [selectedVersion, setSelectedVersion] = useState<string>(modelInfo.version.version);
+    const [selectedVersion, setSelectedVersion] = useState(modelInfo.version);
     return (
         <>
             <PageSection
                 variant={PageSectionVariants.light}
-                style={{paddingTop: 0, paddingBottom: 0}}>
+                style={{ paddingTop: 0, paddingBottom: 0 }}>
                 <Divider />
             </PageSection>
             <PageSection variant={"light"}>
@@ -54,7 +54,7 @@ const ModelLookup = () => {
                     selectedVersion={selectedVersion}
                     onVersionChange={setSelectedVersion}
                 />
-                <ModelDiagram selectedVersion={selectedVersion}/>
+                <ModelDiagram selectedVersion={selectedVersion} />
             </PageSection>
         </>
     );

--- a/src/ModelLookup/ModelOutcomeDialog.tsx
+++ b/src/ModelLookup/ModelOutcomeDialog.tsx
@@ -1,14 +1,15 @@
-import React, {useState} from 'react';
-import {Button, Divider, Modal, Stack, StackItem, Title} from "@patternfly/react-core";
+import React, { useState } from 'react';
+import { Button, Divider, Modal, Stack, StackItem, Title } from "@patternfly/react-core";
 import OutcomeList from "../Outcome/OutcomeList";
+import { IModelVersion } from "../ModelLookup/types"
 
 type MODProps = {
     isOriginalVersion: boolean,
-    selectedVersion: string
+    selectedVersion: IModelVersion
 }
 
-const ModelOutcomeDialog = (props:MODProps) => {
-    const {isOriginalVersion, selectedVersion} = props;
+const ModelOutcomeDialog = (props: MODProps) => {
+    const { isOriginalVersion, selectedVersion } = props;
     const [isModalOpen, setIsModalOpen] = useState(false);
     const handleModalToggle = () => {
         setIsModalOpen(!isModalOpen);
@@ -33,10 +34,10 @@ const ModelOutcomeDialog = (props:MODProps) => {
             >
                 <Stack gutter="md">
                     <StackItem>
-                        <Title size="xl" headingLevel="h4"><strong>{decisionType}</strong> {decisionTitle} <strong>{selectedVersion}</strong></Title>
+                        <Title size="xl" headingLevel="h4"><strong>{decisionType}</strong> {decisionTitle} <strong>{selectedVersion.version}</strong></Title>
                     </StackItem>
                     <StackItem isFilled>
-                        <Divider component="div"/>
+                        <Divider component="div" />
                     </StackItem>
                     <StackItem>
                         <div style={{

--- a/src/ModelLookup/ModelVersionsBrowser.tsx
+++ b/src/ModelLookup/ModelVersionsBrowser.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, { useState } from 'react';
 import {
     Select,
     SelectOption,
@@ -10,14 +10,14 @@ import {
     DataToolbarContent,
     DataToolbarItem
 } from "@patternfly/react-core/dist/js/experimental";
-import {IModelVersion} from "./types";
+import { IModelVersion } from "./types";
 import ModelOutcomeDialog from "./ModelOutcomeDialog";
 
 type propsType = {
     version: IModelVersion,
-    history?: IModelVersion[],
-    selectedVersion: string,
-    onVersionChange: (version:string) => void
+    history: IModelVersion[],
+    selectedVersion: IModelVersion,
+    onVersionChange: (version: IModelVersion) => void
 };
 
 const ModelVersionsBrowser = (props: propsType) => {
@@ -25,14 +25,17 @@ const ModelVersionsBrowser = (props: propsType) => {
     const [isExpanded, setIsExpanded] = useState(false);
     const [isDisabled] = useState(false);
     const versionId = "version-id";
-    const onToggle = (isExpanded:boolean) => {
+    const onToggle = (isExpanded: boolean) => {
         setIsExpanded(isExpanded);
     };
 
-    const onSelect = (event: React.MouseEvent | React.ChangeEvent<Element>, value:string | SelectOptionObject) => {
+    const onSelect = (event: React.MouseEvent | React.ChangeEvent<Element>, value: string | SelectOptionObject) => {
         setIsExpanded(false);
         if (typeof value === "string") {
-            onVersionChange(value);
+            const found: IModelVersion | undefined = getIModelVersion(value, history);
+            if (typeof found !== undefined) {
+                onVersionChange(found as IModelVersion);
+            }
         }
     };
 
@@ -41,41 +44,45 @@ const ModelVersionsBrowser = (props: propsType) => {
             <DataToolbarContent>
                 <DataToolbarItem>
                     <span>
-                        <span>Decision taken by model:</span> <strong>{version.version}</strong>, <span>released on:</span> <strong>{version.releaseDate}</strong>
+                        <span>Decision taken by model:</span> <strong>{selectedVersion.version}</strong>, <span>released on:</span> <strong>{selectedVersion.releaseDate}</strong>
                     </span>
                 </DataToolbarItem>
                 <DataToolbarItem variant="separator" />
                 <DataToolbarItem variant="label">Switch Model Version</DataToolbarItem>
                 <DataToolbarItem>
-                        <Select
-                            id="model-version-history"
-                            className="model-version-browser__history"
-                            variant={SelectVariant.single}
-                            aria-label="Select Input"
-                            onToggle={onToggle}
-                            onSelect={onSelect}
-                            selections={selectedVersion}
-                            isExpanded={isExpanded}
-                            ariaLabelledBy={versionId}
-                            isDisabled={isDisabled}
-                            placeholderText="Choose version"
-                        >
-                            {history && history.map((option, index) => (
-                                <SelectOption
-                                    key={index}
-                                    value={option.version}
-                                    isSelected={(option.version === selectedVersion)}
-                                >{`${option.version} - ${option.releaseDate}`}</SelectOption>
-                            ))}
-                        </Select>
+                    <Select
+                        id="model-version-history"
+                        className="model-version-browser__history"
+                        variant={SelectVariant.single}
+                        aria-label="Select Input"
+                        onToggle={onToggle}
+                        onSelect={onSelect}
+                        selections={selectedVersion.version}
+                        isExpanded={isExpanded}
+                        ariaLabelledBy={versionId}
+                        isDisabled={isDisabled}
+                        placeholderText="Choose version"
+                    >
+                        {history && history.map((option, index) => (
+                            <SelectOption
+                                key={index}
+                                value={option.version}
+                                isSelected={(option.version === selectedVersion.version)}
+                            >{`${option.version} - ${option.releaseDate}`}</SelectOption>
+                        ))}
+                    </Select>
                 </DataToolbarItem>
                 <DataToolbarItem variant="separator" />
                 <DataToolbarItem>
-                    <ModelOutcomeDialog isOriginalVersion={(version.version === selectedVersion)} selectedVersion={selectedVersion}/>
+                    <ModelOutcomeDialog isOriginalVersion={(version === selectedVersion)} selectedVersion={selectedVersion} />
                 </DataToolbarItem>
             </DataToolbarContent>
         </DataToolbar>
     );
 };
+
+function getIModelVersion(version: string, history: IModelVersion[]): IModelVersion | undefined {
+    return history.find(item => item.version === version);
+}
 
 export default ModelVersionsBrowser;


### PR DESCRIPTION
I changed the PoC to pass around a `IModelVersion` rather than a `string` version.

I also changed `useState(..)` to `useReduce` hook although much the same could have been accomplished keeping `useState(..)` for the nested `modelInfo` object and manually setting `modelInfo.version = newModelVersion` in the `ModelVersionsBrowser.onVersionChange` handler but use of _reduce_ vs _state_ seemed to be the way to go for nested properties (according to Google!)

Its easy to develop something with an unfamiliar language the _quick_ way but harder to develop something the _correct_ or _best_ way so I'm just trying to pick up some good habits. I'm sort of using your PoC as my "hello world" (as it's a more realistic starting point than the really simple tutorials).

Reject or merge; I don't mind.. I'm just learning stuff and appreciate any comments.